### PR TITLE
Add Dockerfile for python environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine
+FROM python:3.7
+
+COPY requirements.txt /tmp
+WORKDIR /tmp
+RUN pip install --upgrade pip && \
+    pip install -r requirements.txt


### PR DESCRIPTION
I don't like having to install python3 and it's dependencies through homebrew, prefer to just add a dockerfile and have a virtual environment that I can just run on any machine and use.